### PR TITLE
Feature/error code alert whitelist blacklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea/
 *.xml
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,64 @@ Here's what a telegram message from an example above looks like:
 
 <img src="./message_example.png" width="400">
 
+
+### Blacklists and Whitelists
+
+You can use the `blacklist` and `whitelist` parameters of the `Alerter` class to control which errors should be sent to your Telegram channel and which errors should be excluded.
+
+
+#### Blacklist
+
+The `blacklist` parameter allows you to specify which errors should be excluded from the alerts. Any error type present in the `blacklist` will trigger a message to be sent to the Telegram channel.
+
+##### Example
+```python
+from telegram_exception_alerts import Alerter
+
+tg_alert = Alerter(bot_token='YOUR_BOT_TOKEN', chat_id='YOUR_CHAT_ID', blacklist=["ValueError"])
+
+@tg_alert
+def raise_runtime_error():
+    raise RuntimeError('This is a RuntimeError')
+
+```
+
+In the above example, the `RuntimeError` will not be included in the `blacklist`, so a message will not be sent to the Telegram channel when this exception occurs.
+
+
+```python
+from telegram_exception_alerts import Alerter
+
+tg_alert = Alerter(bot_token='YOUR_BOT_TOKEN', chat_id='YOUR_CHAT_ID', blacklist=["ValueError"])
+
+@tg_alert
+def raise_value_error():
+    raise ValueError('This is a ValueError')
+
+```
+
+In the above example, the ValueError is included in the blacklist, so a message will be sent to the Telegram channel when this exception occurs.
+
+
+#### Whitelist
+
+The `whitelist` parameter allows you to specify which errors **should not** be included in the alerts. Only the error types present in the whitelist will not trigger a message to be sent to the Telegram channel.
+
+
+```python
+from telegram_exception_alerts import Alerter
+
+tg_alert = Alerter(bot_token='YOUR_BOT_TOKEN', chat_id='YOUR_CHAT_ID', whitelist=["RuntimeError"])
+
+@tg_alert
+def raise_runtime_error():
+    raise RuntimeError('This is a RuntimeError')
+
+```
+
+In the above example, the `RuntimeError` is included in the `whitelist`, so a message will not be sent to the Telegram channel for this exception. Other exceptions will trigger a message to be sent.
+
+
 ## Sending messages
 You can also use the `Alerter` as a simple way to send messages to Telegram:
 


### PR DESCRIPTION
# Telegram Exception Alerts - Whitelisting Or Blacklisting

This feature allows you to customize the error codes that are sent to your Telegram account. You can choose to whitelist or blacklist specific error codes, or use a range of codes to filter them. This way, you can avoid getting unnecessary notifications and focus on the errors that matter to you.

You can select the whitelist or blacklist option and enter the error codes you want to include or exclude. Once you save your changes, you will only receive Telegram messages for the error codes that match your criteria.

## Usage

Optionally, you need to specify one or both of the attributes `blacklist: List[str]`, `whitelist: List[str]` with the corresponding error names.

E.g. 

```python
tg_alert = Alerter(
    bot_token='YOUR_BOT_TOKEN',
    chat_id='YOUR_CHAT_ID',
    blacklist=["ValueError"],
    whitelist=["ZeroDivisionError"],
)
```
So, you will receive notifications only for `ValueError`s. 

The `whitelist` has a higher priority than the `blacklist`. So, if the same error exists in both lists, it will not be sent to your telegram channel.
